### PR TITLE
Handle error response when click on cancel without providing credentials

### DIFF
--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticator.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticator.java
@@ -92,9 +92,9 @@ public class LinkedInAuthenticator extends OpenIDConnectAuthenticator implements
             String errorDescription = request.getParameter
                     (LinkedInAuthenticatorConstants.OAUTH2_PARAM_ERROR_DESCRIPTION);
             String state = request.getParameter(LinkedInAuthenticatorConstants.OAUTH2_PARAM_STATE);
-            errorMessage.append("error: ").append(error)
-                    .append(", error_description: ").append(errorDescription)
-                    .append(", state: ").append(state);
+            errorMessage.append(LinkedInAuthenticatorConstants.ERROR).append(error)
+                    .append(LinkedInAuthenticatorConstants.ERROR_DESCRIPTION).append(errorDescription)
+                    .append(LinkedInAuthenticatorConstants.STATE).append(state);
             if (log.isDebugEnabled()) {
                 log.debug("Failed to authenticate via LinkedIn when click on cancel without providing credentials. " +
                         errorMessage.toString());

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
@@ -39,4 +39,6 @@ public class LinkedInAuthenticatorConstants {
     public static final String LAST_NAME = "lastName";
     public static final String USER_ID = "id";
     public static final String CLAIM_DIALECT_URI = "http://wso2.org/linkedin/claims";
+    public static final String OAUTH2_PARAM_ERROR = "error";
+    public static final String OAUTH2_PARAM_ERROR_DESCRIPTION = "error_description";
 }

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
@@ -41,4 +41,7 @@ public class LinkedInAuthenticatorConstants {
     public static final String CLAIM_DIALECT_URI = "http://wso2.org/linkedin/claims";
     public static final String OAUTH2_PARAM_ERROR = "error";
     public static final String OAUTH2_PARAM_ERROR_DESCRIPTION = "error_description";
+    public static final String ERROR = "error: ";
+    public static final String ERROR_DESCRIPTION = ", error_description: ";
+    public static final String STATE = ", state: ";
 }


### PR DESCRIPTION
## Purpose
Handle the error response when click on cancel button without providing the LinkedIn credentials.

## Goals
Handle the specific error and error description when click on cancel button without providing credentials

## Approach
When clicking the "Cancel", from LinkedIn, it will be redirected to IS with following error and error description. Hence handling this error responses in LinkedIn Authenticator.
error - access_denied
error_description - the user denied your request

## User stories

## Release note

## Documentation
N/A

## Training

## Certification
N/A

## Marketing


## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
Jdk 1.8
Ubuntu
 
## Learning