### PR TITLE
Support LinkedIn Version 2 API

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.linkedin</groupId>
         <artifactId>identity-outbound-auth-linkedIn</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.linkedin.connector</artifactId>

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
@@ -20,12 +20,13 @@
 package org.wso2.carbon.identity.authenticator.linkedIn;
 
 public class LinkedInAuthenticatorConstants {
-    public static final String LINKEDIN_OAUTH_ENDPOINT = "https://www.linkedin.com/uas/oauth2/authorization";
-    public static final String LINKEDIN_TOKEN_ENDPOINT = "https://www.linkedin.com/uas/oauth2/accessToken";
-    public static final String LINKEDIN_USERINFO_ENDPOINT = "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,industry,headline,email-address)?format=json";
+    public static final String LINKEDIN_OAUTH_ENDPOINT = "https://www.linkedin.com/oauth/v2/authorization";
+    public static final String LINKEDIN_TOKEN_ENDPOINT = "https://www.linkedin.com/oauth/v2/accessToken";
+    public static final String LINKEDIN_USERINFO_ENDPOINT = "https://api.linkedin.com/v2/me?projection=(firstName,lastName)";
+    public static final String LINKEDIN_USERINFO_EMAILADDRESS = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
     public static final String LINKEDIN_CONNECTOR_FRIENDLY_NAME = "LinkedIn Authenticator";
     public static final String LINKEDIN_CONNECTOR_NAME = "LinkedIn";
-    public static final String QUERY_STRING = "scope=r_basicprofile%20r_emailaddress";
+    public static final String QUERY_STRING = "scope=r_liteprofile%20r_emailaddress%20w_member_social%20r_basicprofile%20w_share%20rw_company_admin";
     public static final String LINKEDIN_OAUTH2_ACCESS_TOKEN_PARAMETER = "oauth2_access_token";
     public static final String LINKEDIN_LOGIN_TYPE = "linkedin";
     public static final String OAUTH2_GRANT_TYPE_CODE = "code";
@@ -44,4 +45,8 @@ public class LinkedInAuthenticatorConstants {
     public static final String ERROR = "error: ";
     public static final String ERROR_DESCRIPTION = ", error_description: ";
     public static final String STATE = ", state: ";
+    public static final String LANGUAGE = "language";
+    public static final String COUNTRY = "country";
+    public static final String EMAIL_ADDRESS = "emailAddress";
+    public static final String HANDLE = "handle~";
 }

--- a/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
+++ b/component/src/main/java/org/wso2/carbon/identity/authenticator/linkedIn/LinkedInAuthenticatorConstants.java
@@ -22,7 +22,7 @@ package org.wso2.carbon.identity.authenticator.linkedIn;
 public class LinkedInAuthenticatorConstants {
     public static final String LINKEDIN_OAUTH_ENDPOINT = "https://www.linkedin.com/oauth/v2/authorization";
     public static final String LINKEDIN_TOKEN_ENDPOINT = "https://www.linkedin.com/oauth/v2/accessToken";
-    public static final String LINKEDIN_USERINFO_ENDPOINT = "https://api.linkedin.com/v2/me?projection=(firstName,lastName)";
+    public static final String LINKEDIN_USERINFO_ENDPOINT = "https://api.linkedin.com/v2/me?projection=(id, firstName,lastName)";
     public static final String LINKEDIN_USERINFO_EMAILADDRESS = "https://api.linkedin.com/v2/emailAddress?q=members&projection=(elements*(handle~))";
     public static final String LINKEDIN_CONNECTOR_FRIENDLY_NAME = "LinkedIn Authenticator";
     public static final String LINKEDIN_CONNECTOR_NAME = "LinkedIn";

--- a/feature/pom.xml
+++ b/feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.linkedin</groupId>
         <artifactId>identity-outbound-auth-linkedIn</artifactId>
-        <version>1.0.4-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <artifactId>org.wso2.carbon.extension.identity.authenticator.linkedin.feature</artifactId>
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     <groupId>org.wso2.carbon.extension.identity.authenticator.outbound.linkedin</groupId>
     <artifactId>identity-outbound-auth-linkedIn</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
     <name>WSO2 Carbon Extension - LinkedIn Pom</name>
     <url>http://wso2.org</url>


### PR DESCRIPTION
## Purpose
> LinkedIn has published this update last December:
https://engineering.linkedin.com/blog/2018/12/developer-program-updates
According to the document, the v1 API will cease to function as of March 1, 2019.

## Goals
> Added support for authentication, token and claims of the new linkedIn Api version;

- [x] Apps with old version api.
- [x] Apps with new version api.

## User stories
> After March 1, 2019, Apps created in Linkedin no longer work in the current version of dropin, because the app uses version 2 of the api.

## Release note
> Due to disapproved fields in LinkedIn, only the emailAddress, firstName, lastName and id claims are available

## Documentation
> https://docs.wso2.com/display/ISCONNECTORS/Configuring+LinkedIn+Authenticator