### PR TITLE
Update identity.core import version range

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Adopt JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/components/org.wso2.carbon.extension.identity.authenticator.linkedin.connector/pom.xml
+++ b/components/org.wso2.carbon.extension.identity.authenticator.linkedin.connector/pom.xml
@@ -144,6 +144,7 @@
                             org.osgi.service.component.*,
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             javax.servlet,
                             javax.servlet.http,
                             org.apache.oltu.oauth2.*;version="${oltu.package.import.version.range}",

--- a/components/org.wso2.carbon.extension.identity.authenticator.linkedin.oidc.connector/pom.xml
+++ b/components/org.wso2.carbon.extension.identity.authenticator.linkedin.oidc.connector/pom.xml
@@ -144,6 +144,7 @@
                             org.osgi.service.component.*,
                             org.wso2.carbon.identity.application.authentication.framework.*;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             javax.servlet,
                             javax.servlet.http,
                             org.apache.oltu.oauth2.*;version="${oltu.package.import.version.range}",

--- a/pom.xml
+++ b/pom.xml
@@ -245,3 +245,4 @@
         <carbon.identity.package.import.version.range>[5.0.0,8.0.0)</carbon.identity.package.import.version.range>
     </properties>
 </project>
+


### PR DESCRIPTION
## Purpose
When using the LinkedIn OIDC Authenticator (`org.wso2.carbon.extension.identity.authenticator.linkedin.oidc.connector_2.1.0`) on IS 7.0, authentication fails due to a missing class `org.wso2.carbon.identity.core.util.IdentityUtil`. As the versions range is not defined for `org.wso2.carbon.identity.core.util` there is a version incompatibility in the runtime which leads to the above error.

